### PR TITLE
Fix interupt functions

### DIFF
--- a/Adafruit_AMG88xx/Adafruit_AMG88xx.py
+++ b/Adafruit_AMG88xx/Adafruit_AMG88xx.py
@@ -129,21 +129,22 @@ class Adafruit_AMG88xx(object):
 
 	def setInterruptLevels(self, high, low, hysteresis):
 
-		highConv = high / AMG88xx_PIXEL_TEMP_CONVERSION
+		highConv = int(high / AMG88xx_PIXEL_TEMP_CONVERSION)
 		highConv = constrain(highConv, -4095, 4095)
 		self._inthl.INT_LVL_H = highConv & 0xFF
+
 		self._inthh.INT_LVL_H = (highConv & 0xF) >> 4
 		self._device.write8(AMG88xx_INTHL, self._inthl.get())
 		self._device.write8(AMG88xx_INTHH, self._inthh.get())
 
-		lowConv = low / AMG88xx_PIXEL_TEMP_CONVERSION
+		lowConv = int(low / AMG88xx_PIXEL_TEMP_CONVERSION)
 		lowConv = constrain(lowConv, -4095, 4095)
 		self._intll.INT_LVL_L = lowConv & 0xFF
 		self._intlh.INT_LVL_L = (lowConv & 0xF) >> 4
 		self._device.write8(AMG88xx_INTLL, self._intll.get())
 		self._device.write8(AMG88xx_INTLH, self._intlh.get())
 
-		hysConv = hysteresis / AMG88xx_PIXEL_TEMP_CONVERSION
+		hysConv = int(hysteresis / AMG88xx_PIXEL_TEMP_CONVERSION)
 		hysConv = constrain(hysConv, -4095, 4095)
 		self._ihysl.INT_HYS = hysConv & 0xFF
 		self._ihysh.INT_HYS = (hysConv & 0xF) >> 4
@@ -172,7 +173,7 @@ class Adafruit_AMG88xx(object):
 	def getInterrupt(self):
 		buf = []
 		for i in range(0, 8):
-			buf.append(self._device.read8(AMG88xx_INT_OFFSET + i))
+			buf.append(self._device.readU8(AMG88xx_INT_OFFSET + i))
 			
 		return buf
 

--- a/examples/interupt.py
+++ b/examples/interupt.py
@@ -1,0 +1,18 @@
+from Adafruit_AMG88xx import Adafruit_AMG88xx, AMG88xx_ABSOLUTE_VALUE
+from gpiozero import Button
+
+# connect the INT (interupt) pin to GPIO 17
+interupt = Button(17)
+sensor = Adafruit_AMG88xx()
+
+sensor.setInterruptLevels(30, 50, 50 * .95)
+sensor.setInterruptMode(AMG88xx_ABSOLUTE_VALUE)
+sensor.enableInterrupt()
+
+interupt.wait_for_press()
+
+print("interupted")
+
+print(sensor.getInterrupt())
+
+sensor.disableInterrupt()

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ classifiers = ['Development Status :: 4 - Beta',
                'Topic :: System :: Hardware']
 
 setup(name              = 'Adafruit_AMG88xx',
-      version           = '1.3',
+      version           = '1.4',
       author            = 'Dean Miller',
       author_email      = 'dean@adafruit.com',
       description       = 'Python library to use the AMG88xx Grid-EYE 8x8 thermal sensor with raspberry pi or other linux boards.',


### PR DESCRIPTION
There were issues with:

setInterruptLevels()
```
Traceback (most recent call last):
  File "/home/pi/amg8833_interupt.py", line 7, in <module>
    sensor.setInterruptLevels(0x1E,0x32,0x31)
  File "/usr/local/lib/python3.5/dist-packages/Adafruit_AMG88xx-1.3-py3.5.egg/Adafruit_AMG88xx/Adafruit_AMG88xx.py", line 134, in setInterruptLevels
    self._inthl.INT_LVL_H = highConv & 0xFF
TypeError: unsupported operand type(s) for &: 'float' and 'int'
```

getInterrupt()
```
Traceback (most recent call last):
  File "/home/pi/amg8833_interupt.py", line 13, in <module>
    print(sensor.getInterrupt())
  File "/usr/local/lib/python3.5/dist-packages/Adafruit_AMG88xx/Adafruit_AMG88xx.py", line 175, in getInterrupt
    buf.append(self._device.read8(AMG88xx_INT_OFFSET + i))
AttributeError: 'Device' object has no attribute 'read8'
```

I have added a interupt example.

I also incremented the version to 1.4.
